### PR TITLE
Add troubleshooting section to README and modified ansible.cfg

### DIFF
--- a/driver-kafka/deploy/confluent-deployment/ansible.cfg
+++ b/driver-kafka/deploy/confluent-deployment/ansible.cfg
@@ -4,7 +4,18 @@ private_key_file=~/.ssh/omb
 timeout=60
 inventory = hosts.ini
 
+; Use this config if you are with old 'sudo' plugin (ansible-doc -t become -l)
+; [privilege_escalation]
+; become=true
+; become_method='sudo'
+; become_user='root'
+
+; Use this config if you are with new 'ansible.builtin.sudo' plugin (ansible-doc -t become -l)
 [privilege_escalation]
 become=true
-become_method='sudo'
+become_exe = sudo
 become_user='root'
+
+[sudo_become_plugin]
+executable = sudo
+user = root


### PR DESCRIPTION
`become_method='sudo'` is no longer working with plugin `ansible.builtin.sudo`. So update the cfg file (and commented out the old configuration in case you're still with the old sudo plugin)